### PR TITLE
IRC Tags

### DIFF
--- a/Clients/Irc/IrcClient.EventArgs.cs
+++ b/Clients/Irc/IrcClient.EventArgs.cs
@@ -509,7 +509,7 @@ TwitchNet.Clients.Irc
 
             if (tags_exist)
             {
-                tags = new PrivmsgTags(irc_message);
+                tags = new PrivmsgTags(irc_message.tags);
             }
         }
     }
@@ -623,28 +623,28 @@ TwitchNet.Clients.Irc
         [IrcTag("emotes")]
         public Emote[] emotes { get; protected set; }
 
-        public PrivmsgTags(IrcMessage message)
+        public PrivmsgTags(in IrcTags tags)
         {
-            bits = TwitchIrcUtil.Tags.ToUInt32(message, "bits");
+            bits            = TwitchIrcUtil.Tags.ToUInt32(tags, "bits");
 
-            mod = TwitchIrcUtil.Tags.ToBool(message, "mod");
-            subscriber = TwitchIrcUtil.Tags.ToBool(message, "subscriber");
-            turbo = TwitchIrcUtil.Tags.ToBool(message, "turbo");
-            emote_only = TwitchIrcUtil.Tags.ToBool(message, "emote-only");
+            mod             = TwitchIrcUtil.Tags.ToBool(tags, "mod");
+            subscriber      = TwitchIrcUtil.Tags.ToBool(tags, "subscriber");
+            turbo           = TwitchIrcUtil.Tags.ToBool(tags, "turbo");
+            emote_only      = TwitchIrcUtil.Tags.ToBool(tags, "emote-only");
 
-            id = TwitchIrcUtil.Tags.ToString(message, "id");
-            display_name = TwitchIrcUtil.Tags.ToString(message, "display-name");
-            user_id = TwitchIrcUtil.Tags.ToString(message, "user-id");
-            room_id = TwitchIrcUtil.Tags.ToString(message, "room-id");
+            id              = TwitchIrcUtil.Tags.ToString(tags, "id");
+            display_name    = TwitchIrcUtil.Tags.ToString(tags, "display-name");
+            user_id         = TwitchIrcUtil.Tags.ToString(tags, "user-id");
+            room_id         = TwitchIrcUtil.Tags.ToString(tags, "room-id");
 
-            user_type = TwitchIrcUtil.Tags.ToUserType(message, "user-type");
+            user_type       = TwitchIrcUtil.Tags.ToEnum<UserType>(tags, "user-type");
 
-            color = TwitchIrcUtil.Tags.FromtHtml(message, "color");
-            tmi_sent_ts = TwitchIrcUtil.Tags.FromUnixEpochMilliseconds(message, "tmi-sent-ts");
+            color           = TwitchIrcUtil.Tags.FromtHtml(tags, "color");
+            tmi_sent_ts     = TwitchIrcUtil.Tags.FromUnixEpochMilliseconds(tags, "tmi-sent-ts");
 
-            badges = TwitchIrcUtil.Tags.ToBadges(message, "badges");
-            badge_info = TwitchIrcUtil.Tags.ToBadgeInfo(message, "badge-info");
-            emotes = TwitchIrcUtil.Tags.ToEmotes(message, "emotes");
+            badges          = TwitchIrcUtil.Tags.ToBadges(tags, "badges");
+            badge_info      = TwitchIrcUtil.Tags.ToBadgeInfo(tags, "badge-info");
+            emotes          = TwitchIrcUtil.Tags.ToEmotes(tags, "emotes");
         }
     }
 
@@ -935,7 +935,7 @@ TwitchNet.Clients.Irc
             tags_exist = message.tags_exist;
             if (tags_exist)
             {
-                tags = new NoticeTags(message);
+                tags = new NoticeTags(message.tags);
             }
 
             if (message.parameters.Length > 0)
@@ -958,9 +958,9 @@ TwitchNet.Clients.Irc
         public NoticeType msg_id { get; protected set; }
 
         public
-        NoticeTags(in IrcMessage message)
+        NoticeTags(in IrcTags tags)
         {
-            msg_id = TwitchIrcUtil.Tags.ToNoticeType(message, "msg-id");
+            msg_id = TwitchIrcUtil.Tags.ToEnum<NoticeType>(tags, "msg-id");
         }
     }
 

--- a/Clients/Irc/TwitchIrcClient.EventArgs.cs
+++ b/Clients/Irc/TwitchIrcClient.EventArgs.cs
@@ -57,7 +57,7 @@ TwitchNet.Clients.Irc
             tags_exist = message.tags_exist;
             if (tags_exist)
             {
-                tags = new ClearChatTags(message);
+                tags = new ClearChatTags(message.tags);
             }
 
             if (message.parameters.Length > 0)
@@ -106,13 +106,13 @@ TwitchNet.Clients.Irc
         public DateTime tmi_sent_ts { get; protected set; }
 
         public
-        ClearChatTags(in IrcMessage message)
+        ClearChatTags(in IrcTags tags)
         {
-            ban_duration    = TwitchIrcUtil.Tags.ToTimeSpanFromSeconds(message, "ban-duration");
-            ban_reason      = TwitchIrcUtil.Tags.ToString(message, "ban-reason").Replace("\\s", " ");
-            room_id         = TwitchIrcUtil.Tags.ToString(message, "room-id");
-            target_user_id  = TwitchIrcUtil.Tags.ToString(message, "target-user-id");
-            tmi_sent_ts     = TwitchIrcUtil.Tags.FromUnixEpochMilliseconds(message, "tmi-sent-ts");
+            ban_duration    = TwitchIrcUtil.Tags.ToTimeSpanFromSeconds(tags, "ban-duration");
+            ban_reason      = TwitchIrcUtil.Tags.ToString(tags, "ban-reason").Replace("\\s", " ");
+            room_id         = TwitchIrcUtil.Tags.ToString(tags, "room-id");
+            target_user_id  = TwitchIrcUtil.Tags.ToString(tags, "target-user-id");
+            tmi_sent_ts     = TwitchIrcUtil.Tags.FromUnixEpochMilliseconds(tags, "tmi-sent-ts");
         }
     }
 
@@ -141,7 +141,7 @@ TwitchNet.Clients.Irc
             tags_exist = message.tags_exist;
             if (tags_exist)
             {
-                tags = new GlobalUserStateTags(message);
+                tags = new GlobalUserStateTags(message.tags);
             }
         }
     }
@@ -198,18 +198,18 @@ TwitchNet.Clients.Irc
         public BadgeInfo[] badge_info { get; protected set; }
 
         public
-        GlobalUserStateTags(in IrcMessage message)
+        GlobalUserStateTags(in IrcTags tags)
         {
-            user_id = TwitchIrcUtil.Tags.ToString(message, "user-id");
-            display_name = TwitchIrcUtil.Tags.ToString(message, "display-name");
-            emote_sets = TwitchIrcUtil.Tags.ToStringArray(message, "emote-sets", ',');
+            user_id         = TwitchIrcUtil.Tags.ToString(tags, "user-id");
+            display_name    = TwitchIrcUtil.Tags.ToString(tags, "display-name");
+            emote_sets      = TwitchIrcUtil.Tags.ToStringArray(tags, "emote-sets", ',');
 
-            user_type = TwitchIrcUtil.Tags.ToUserType(message, "user-type");
+            user_type       = TwitchIrcUtil.Tags.ToEnum<UserType>(tags, "user-type");
 
-            color = TwitchIrcUtil.Tags.FromtHtml(message, "color");
+            color           = TwitchIrcUtil.Tags.FromtHtml(tags, "color");
 
-            badges = TwitchIrcUtil.Tags.ToBadges(message, "badges");
-            badge_info = TwitchIrcUtil.Tags.ToBadgeInfo(message, "badge-info");
+            badges          = TwitchIrcUtil.Tags.ToBadges(tags, "badges");
+            badge_info      = TwitchIrcUtil.Tags.ToBadgeInfo(tags, "badge-info");
         }
     }
 
@@ -335,7 +335,7 @@ TwitchNet.Clients.Irc
             tags_exist = message.tags_exist;
             if (tags_exist)
             {
-                tags = new RoomStateTags(message);
+                tags = new RoomStateTags(message.tags);
             }
 
             if (message.parameters.Length > 0)
@@ -411,45 +411,45 @@ TwitchNet.Clients.Irc
         public RoomStateType changed_states { get; protected set; }
 
         public
-        RoomStateTags(in IrcMessage message)
+        RoomStateTags(in IrcTags tags)
         {
-            if (TwitchIrcUtil.Tags.IsTagValid(message, "emote-only"))
+            if (tags.ContainsKey("emote-only"))
             {
-                emote_only = TwitchIrcUtil.Tags.ToBool(message, "emote-only");
+                emote_only = TwitchIrcUtil.Tags.ToBool(tags, "emote-only");
                 changed_states |= RoomStateType.EmoteOnly;
             }
 
-            if (TwitchIrcUtil.Tags.IsTagValid(message, "r9k"))
+            if (tags.ContainsKey("r9k"))
             {
-                r9k = TwitchIrcUtil.Tags.ToBool(message, "r9k");
+                r9k = TwitchIrcUtil.Tags.ToBool(tags, "r9k");
                 changed_states |= RoomStateType.R9K;
             }
 
-            if (TwitchIrcUtil.Tags.IsTagValid(message, "rituals"))
+            if (tags.ContainsKey("rituals"))
             {
-                rituals = TwitchIrcUtil.Tags.ToBool(message, "rituals");
+                rituals = TwitchIrcUtil.Tags.ToBool(tags, "rituals");
                 changed_states |= RoomStateType.Rituals;
             }
 
-            if (TwitchIrcUtil.Tags.IsTagValid(message, "subs-only"))
+            if (tags.ContainsKey("subs-only"))
             {
-                subs_only = TwitchIrcUtil.Tags.ToBool(message, "subs-only");
+                subs_only = TwitchIrcUtil.Tags.ToBool(tags, "subs-only");
                 changed_states |= RoomStateType.SubsOnly;
             }
 
-            if (TwitchIrcUtil.Tags.IsTagValid(message, "followers-only"))
+            if (tags.ContainsKey("followers-only"))
             {
-                followers_only = TwitchIrcUtil.Tags.ToInt32(message, "followers-only");
+                followers_only = TwitchIrcUtil.Tags.ToInt32(tags, "followers-only");
                 changed_states |= RoomStateType.FollowersOnly;
             }
 
-            if (TwitchIrcUtil.Tags.IsTagValid(message, "slow"))
+            if (tags.ContainsKey("slow"))
             {
-                slow = TwitchIrcUtil.Tags.ToInt32(message, "slow");
+                slow = TwitchIrcUtil.Tags.ToInt32(tags, "slow");
                 changed_states |= RoomStateType.Slow;
             }
 
-            room_id = TwitchIrcUtil.Tags.ToString(message, "room-id");
+            room_id = TwitchIrcUtil.Tags.ToString(tags, "room-id");
         }
     }
 
@@ -536,7 +536,7 @@ TwitchNet.Clients.Irc
             tags_exist = message.tags_exist;
             if (tags_exist)
             {
-                tags = new UserNoticeTags(message);
+                tags = new UserNoticeTags(message.tags);
             }
 
             if (message.parameters.Length > 0)
@@ -664,25 +664,25 @@ TwitchNet.Clients.Irc
         public UserType user_type { get; protected set; }
 
         public
-        UserNoticeBaseTags(in IrcMessage message)
+        UserNoticeBaseTags(in IrcTags tags)
         {
             // Universal tags
-            badges          = TwitchIrcUtil.Tags.ToBadges(message, "badges");
-            badge_info      = TwitchIrcUtil.Tags.ToBadgeInfo(message, "badge-info");
-            color           = TwitchIrcUtil.Tags.FromtHtml(message, "color");
-            display_name    = TwitchIrcUtil.Tags.ToString(message, "display-name");
-            emotes          = TwitchIrcUtil.Tags.ToEmotes(message, "emotes");
-            id              = TwitchIrcUtil.Tags.ToString(message, "id");
-            login           = TwitchIrcUtil.Tags.ToString(message, "login");
-            mod             = TwitchIrcUtil.Tags.ToBool(message, "mod");
-            msg_id          = TwitchIrcUtil.Tags.ToUserNoticeType(message, "msg-id");
-            room_id         = TwitchIrcUtil.Tags.ToString(message, "room-id");
-            subscriber      = TwitchIrcUtil.Tags.ToBool(message, "subscriber");
-            system_msg      = TwitchIrcUtil.Tags.ToString(message, "system-msg").Replace("\\s", " ");
-            tmi_sent_ts     = TwitchIrcUtil.Tags.FromUnixEpochMilliseconds(message, "tmi-sent-ts");
-            turbo           = TwitchIrcUtil.Tags.ToBool(message, "turbo");
-            user_id         = TwitchIrcUtil.Tags.ToString(message, "user-id");
-            user_type       = TwitchIrcUtil.Tags.ToUserType(message, "user-type");
+            badges          = TwitchIrcUtil.Tags.ToBadges(tags, "badges");
+            badge_info      = TwitchIrcUtil.Tags.ToBadgeInfo(tags, "badge-info");
+            color           = TwitchIrcUtil.Tags.FromtHtml(tags, "color");
+            display_name    = TwitchIrcUtil.Tags.ToString(tags, "display-name");
+            emotes          = TwitchIrcUtil.Tags.ToEmotes(tags, "emotes");
+            id              = TwitchIrcUtil.Tags.ToString(tags, "id");
+            login           = TwitchIrcUtil.Tags.ToString(tags, "login");
+            mod             = TwitchIrcUtil.Tags.ToBool(tags, "mod");
+            msg_id          = TwitchIrcUtil.Tags.ToEnum<UserNoticeType>(tags, "msg-id");
+            room_id         = TwitchIrcUtil.Tags.ToString(tags, "room-id");
+            subscriber      = TwitchIrcUtil.Tags.ToBool(tags, "subscriber");
+            system_msg      = TwitchIrcUtil.Tags.ToString(tags, "system-msg").Replace("\\s", " ");
+            tmi_sent_ts     = TwitchIrcUtil.Tags.FromUnixEpochMilliseconds(tags, "tmi-sent-ts");
+            turbo           = TwitchIrcUtil.Tags.ToBool(tags, "turbo");
+            user_id         = TwitchIrcUtil.Tags.ToString(tags, "user-id");
+            user_type       = TwitchIrcUtil.Tags.ToEnum<UserType>(tags, "user-type");
         }
 
         public
@@ -917,40 +917,40 @@ TwitchNet.Clients.Irc
         public int msg_param_threshold { get; protected set; } = -1;
 
         public
-        UserNoticeTags(in IrcMessage message) : base(message)
+        UserNoticeTags(in IrcTags tags) : base(tags)
         {
             // sub, resub tags
             if(msg_id == UserNoticeType.Sub || 
                msg_id == UserNoticeType.Resub)
             {
-                msg_param_cumulative_months         = TwitchIrcUtil.Tags.ToInt32(message, "msg-param-cumulative-months");
-                msg_param_should_share_streak       = TwitchIrcUtil.Tags.ToBool(message, "msg-param-should-share-streak");
-                msg_param_streak_months             = TwitchIrcUtil.Tags.ToInt32(message, "msg-param-months");
+                msg_param_cumulative_months         = TwitchIrcUtil.Tags.ToInt32(tags, "msg-param-cumulative-months");
+                msg_param_should_share_streak       = TwitchIrcUtil.Tags.ToBool(tags, "msg-param-should-share-streak");
+                msg_param_streak_months             = TwitchIrcUtil.Tags.ToInt32(tags, "msg-param-months");
             }
 
             // subgift, anonsubgift tags
             if (msg_id == UserNoticeType.SubGift ||
                 msg_id == UserNoticeType.AnonSubGift)
             {
-                msg_param_months                    = TwitchIrcUtil.Tags.ToInt32(message, "msg-param-months");
-                msg_param_recipient_display_name    = TwitchIrcUtil.Tags.ToString(message, "msg-param-recipient-display-name");
-                msg_param_recipient_id              = TwitchIrcUtil.Tags.ToString(message, "msg-param-recipient-id");
-                msg_param_recipient_user_name       = TwitchIrcUtil.Tags.ToString(message, "msg-param-recipient-user-name");
+                msg_param_months                    = TwitchIrcUtil.Tags.ToInt32(tags, "msg-param-months");
+                msg_param_recipient_display_name    = TwitchIrcUtil.Tags.ToString(tags, "msg-param-recipient-display-name");
+                msg_param_recipient_id              = TwitchIrcUtil.Tags.ToString(tags, "msg-param-recipient-id");
+                msg_param_recipient_user_name       = TwitchIrcUtil.Tags.ToString(tags, "msg-param-recipient-user-name");
             }
 
             // giftpaidupgrade tags
             if (msg_id == UserNoticeType.GiftPaidUpgrade)
             {
-                msg_param_sender_login              = TwitchIrcUtil.Tags.ToString(message, "msg-param-sender-login");
-                msg_param_sender_name               = TwitchIrcUtil.Tags.ToString(message, "msg-param-sender-name");
+                msg_param_sender_login              = TwitchIrcUtil.Tags.ToString(tags, "msg-param-sender-login");
+                msg_param_sender_name               = TwitchIrcUtil.Tags.ToString(tags, "msg-param-sender-name");
             }
 
             // giftpaidupgrade, anongiftpaidupgrade tags
             if (msg_id == UserNoticeType.GiftPaidUpgrade ||
                 msg_id == UserNoticeType.AnonGiftPaidUpgrade)
             {
-                msg_param_promo_gift_total          = TwitchIrcUtil.Tags.ToInt32(message, "msg-param-promo-gift-total");
-                msg_param_promo_name                = TwitchIrcUtil.Tags.ToString(message, "msg-param-promo-name");
+                msg_param_promo_gift_total          = TwitchIrcUtil.Tags.ToInt32(tags, "msg-param-promo-gift-total");
+                msg_param_promo_name                = TwitchIrcUtil.Tags.ToString(tags, "msg-param-promo-name");
             }
 
             // sub, resub, subgift, anonsubgift tags
@@ -959,28 +959,28 @@ TwitchNet.Clients.Irc
                 msg_id == UserNoticeType.SubGift    ||
                 msg_id == UserNoticeType.AnonSubGift)
             {
-                msg_param_sub_plan                  = TwitchIrcUtil.Tags.ToSubscriptionPlan(message, "msg-param-sub-plan");
-                msg_param_sub_plan_name             = TwitchIrcUtil.Tags.ToString(message, "msg-param-sub-plan-name");
+                msg_param_sub_plan                  = TwitchIrcUtil.Tags.ToEnum<SubscriptionTier>(tags, "msg-param-sub-plan");
+                msg_param_sub_plan_name             = TwitchIrcUtil.Tags.ToString(tags, "msg-param-sub-plan-name");
             }
 
             // raid tags
             if (msg_id == UserNoticeType.Raid)
             {
-                msg_param_viewer_count              = TwitchIrcUtil.Tags.ToInt32(message, "msg-param-viewerCount");
-                msg_param_display_name              = TwitchIrcUtil.Tags.ToString(message, "msg-param-displayName");
-                msg_param_login                     = TwitchIrcUtil.Tags.ToString(message, "msg-param-login");
+                msg_param_viewer_count              = TwitchIrcUtil.Tags.ToInt32(tags, "msg-param-viewerCount");
+                msg_param_display_name              = TwitchIrcUtil.Tags.ToString(tags, "msg-param-displayName");
+                msg_param_login                     = TwitchIrcUtil.Tags.ToString(tags, "msg-param-login");
             }
 
             // ritual tags
             if (msg_id == UserNoticeType.Ritual)
             {
-                msg_param_ritual_name = TwitchIrcUtil.Tags.ToRitualType(message, "msg-param-ritual-name");
+                msg_param_ritual_name               = TwitchIrcUtil.Tags.ToEnum<RitualType>(tags, "msg-param-ritual-name");
             }
 
             // bitsbadgetier tags
             if (msg_id == UserNoticeType.BitsBadgeTier)
             {
-                msg_param_threshold = TwitchIrcUtil.Tags.ToInt32(message, "msg-param-threshold");
+                msg_param_threshold                 = TwitchIrcUtil.Tags.ToInt32(tags, "msg-param-threshold");
             }
         }
     }
@@ -1453,7 +1453,7 @@ TwitchNet.Clients.Irc
             tags_exist = message.tags_exist;
             if (tags_exist)
             {
-                tags = new UserStateTags(message);
+                tags = new UserStateTags(message.tags);
             }
 
             if (message.parameters.Length > 0)
@@ -1521,21 +1521,21 @@ TwitchNet.Clients.Irc
         [IrcTag("badge-info")]
         public BadgeInfo[] badge_info { get; protected set; }
 
-        public UserStateTags(in IrcMessage message)
+        public UserStateTags(in IrcTags tags)
         {
-            mod = TwitchIrcUtil.Tags.ToBool(message, "mod");
+            mod             = TwitchIrcUtil.Tags.ToBool(tags, "mod");
 
-            display_name = TwitchIrcUtil.Tags.ToString(message, "display-name");
-            emote_sets = TwitchIrcUtil.Tags.ToStringArray(message, "emote-sets", ',');
+            display_name    = TwitchIrcUtil.Tags.ToString(tags, "display-name");
+            emote_sets      = TwitchIrcUtil.Tags.ToStringArray(tags, "emote-sets", ',');
 
-            user_type = TwitchIrcUtil.Tags.ToUserType(message, "user-type");
+            user_type       = TwitchIrcUtil.Tags.ToEnum<UserType>(tags, "user-type");
 
-            color = TwitchIrcUtil.Tags.FromtHtml(message, "color");
+            color           = TwitchIrcUtil.Tags.FromtHtml(tags, "color");
 
-            subscriber = TwitchIrcUtil.Tags.ToBool(message, "subscriber");
+            subscriber      = TwitchIrcUtil.Tags.ToBool(tags, "subscriber");
 
-            badges = TwitchIrcUtil.Tags.ToBadges(message, "badges");
-            badge_info = TwitchIrcUtil.Tags.ToBadgeInfo(message, "badges");
+            badges          = TwitchIrcUtil.Tags.ToBadges(tags, "badges");
+            badge_info      = TwitchIrcUtil.Tags.ToBadgeInfo(tags, "badges");
         }
     }
 
@@ -1583,7 +1583,7 @@ TwitchNet.Clients.Irc
             tags_exist = message.tags_exist;
             if (tags_exist)
             {
-                tags = new WhisperTags(message);
+                tags = new WhisperTags(message.tags);
             }
 
             sender = message.server_or_nick;
@@ -1669,22 +1669,22 @@ TwitchNet.Clients.Irc
         public Emote[] emotes { get; protected set; }
 
         public
-        WhisperTags(in IrcMessage message)
+        WhisperTags(in IrcTags tags)
         {
-            turbo = TwitchIrcUtil.Tags.ToBool(message, "turbo");
+            turbo           = TwitchIrcUtil.Tags.ToBool(tags, "turbo");
 
-            display_name = TwitchIrcUtil.Tags.ToString(message, "display-name");
-            user_id = TwitchIrcUtil.Tags.ToString(message, "user-id");
-            message_id = TwitchIrcUtil.Tags.ToString(message, "message-id");
-            thread_id = TwitchIrcUtil.Tags.ToString(message, "thread-id");
-            recipient_id = thread_id.TextAfter('_');
+            display_name    = TwitchIrcUtil.Tags.ToString(tags, "display-name");
+            user_id         = TwitchIrcUtil.Tags.ToString(tags, "user-id");
+            message_id      = TwitchIrcUtil.Tags.ToString(tags, "message-id");
+            thread_id       = TwitchIrcUtil.Tags.ToString(tags, "thread-id");
+            recipient_id    = thread_id.TextAfter('_');
 
-            user_type = TwitchIrcUtil.Tags.ToUserType(message, "user-type");
+            user_type       = TwitchIrcUtil.Tags.ToEnum<UserType>(tags, "user-type");
 
-            color = TwitchIrcUtil.Tags.FromtHtml(message, "color");
+            color           = TwitchIrcUtil.Tags.FromtHtml(tags, "color");
 
-            badges = TwitchIrcUtil.Tags.ToBadges(message, "badges");
-            emotes = TwitchIrcUtil.Tags.ToEmotes(message, "emotes");
+            badges          = TwitchIrcUtil.Tags.ToBadges(tags, "badges");
+            emotes          = TwitchIrcUtil.Tags.ToEmotes(tags, "emotes");
         }
     }
 

--- a/Clients/Irc/TwitchIrcUtil.cs
+++ b/Clients/Irc/TwitchIrcUtil.cs
@@ -406,14 +406,14 @@ TwitchNet.Clients.Irc
             /// Returns <see cref="string.Empty"/> otherwise.
             /// </returns>
             public static string
-            ToString(in IrcMessage message, string key)
+            ToString(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return string.Empty;
                 }
 
-                return message.tags[key];
+                return value;
             }
 
             /// <summary>
@@ -426,16 +426,16 @@ TwitchNet.Clients.Irc
             /// Returns 0 otherwise.
             /// </returns>
             public static ushort
-            ToUInt16(in IrcMessage message, string key)
+            ToUInt16(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return 0;
                 }
 
-                UInt16.TryParse(message.tags[key], out ushort value);
+                UInt16.TryParse(value, out ushort _value);
 
-                return value;
+                return _value;
             }
 
             /// <summary>
@@ -448,16 +448,16 @@ TwitchNet.Clients.Irc
             /// Returns 0 otherwise.
             /// </returns>
             public static uint
-            ToUInt32(in IrcMessage message, string key)
+            ToUInt32(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return 0;
                 }
 
-                UInt32.TryParse(message.tags[key], out uint value);
+                UInt32.TryParse(value, out uint _value);
 
-                return value;
+                return _value;
             }
 
             /// <summary>
@@ -470,9 +470,9 @@ TwitchNet.Clients.Irc
             /// Returns <see cref="TimeSpan.Zero"/> otherwise.
             /// </returns>
             public static TimeSpan
-            ToTimeSpanFromSeconds(in IrcMessage message, string key)
+            ToTimeSpanFromSeconds(in IrcTags tags, string key)
             {
-                int seconds = ToInt32(message, key);
+                int seconds = ToInt32(tags, key);
 
                 TimeSpan time = seconds == 0 ? TimeSpan.Zero : new TimeSpan(0, 0, seconds);
 
@@ -489,16 +489,16 @@ TwitchNet.Clients.Irc
             /// Returns -1 otherwise.
             /// </returns>
             public static int
-            ToInt32(in IrcMessage message, string key)
+            ToInt32(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return -1;
                 }
 
-                Int32.TryParse(message.tags[key], out int value);
+                Int32.TryParse(value, out int _value);
 
-                return value;
+                return _value;
             }
 
             /// <summary>
@@ -511,14 +511,14 @@ TwitchNet.Clients.Irc
             /// Returns false otherwise.
             /// </returns>
             public static bool
-            ToBool(in IrcMessage message, string key)
+            ToBool(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return default;
                 }
 
-                if (!Byte.TryParse(message.tags[key], out byte _value))
+                if (!Byte.TryParse(value, out byte _value))
                 {
                     return default;
                 }
@@ -527,133 +527,29 @@ TwitchNet.Clients.Irc
             }
 
             /// <summary>
-            /// Converts a tag to an equivalent <see cref="UserType"/> value.
+            /// Converts a tag to an equivalent enum value.
             /// </summary>
             /// <param name="tags">The IRC message tags.</param>
             /// <param name="key">The tag to convert.</param>
             /// <returns>
-            /// Returns the equivalent <see cref="UserType"/> value if the tag was able to be converted.
-            /// Returns <see cref="UserType.None"/> otherwise.
+            /// Returns the equivalent enum value if the tag was able to be converted.
+            /// Returns the enum's default value otherwise.
             /// </returns>
-            public static UserType
-            ToUserType(in IrcMessage message, string key)
+            public static enum_type
+            ToEnum<enum_type>(in IrcTags tags, string key)
+            where enum_type : struct
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
-                    return UserType.None;
+                    return default;
                 }
 
-                return EnumUtil.Parse<UserType>(message.tags[key]);
-            }
-
-            /// <summary>
-            /// Converts a tag to an equivalent <see cref="NoticeType"/> value.
-            /// </summary>
-            /// <param name="tags">The IRC message tags.</param>
-            /// <param name="key">The tag to convert.</param>
-            /// <returns>
-            /// Returns the equivalent <see cref="NoticeType"/> value if the tag was able to be converted.
-            /// Returns <see cref="NoticeType.Other"/> otherwise.
-            /// </returns>
-            public static NoticeType
-            ToNoticeType(in IrcMessage message, string key)
-            {
-                if (!IsTagValid(message, key))
+                if (!EnumUtil.TryParse(value, out enum_type _value))
                 {
-                    return NoticeType.Other;
+                    return default;
                 }
 
-                EnumUtil.TryParse(message.tags[key], out NoticeType notice);
-
-                return notice;
-            }
-
-            /// <summary>
-            /// Converts a tag to an equivalent <see cref="UserNoticeType"/> value.
-            /// </summary>
-            /// <param name="tags">The IRC message tags.</param>
-            /// <param name="key">The tag to convert.</param>
-            /// <returns>
-            /// Returns the equivalent <see cref="UserNoticeType"/> value if the tag was able to be converted.
-            /// Returns <see cref="UserNoticeType.Other"/> otherwise.
-            /// </returns>
-            public static UserNoticeType
-            ToUserNoticeType(in IrcMessage message, string key)
-            {
-                if (!IsTagValid(message, key))
-                {
-                    return UserNoticeType.Other;
-                }
-
-                EnumUtil.TryParse(message.tags[key], out UserNoticeType user_notice);
-
-                return user_notice;
-            }
-
-            /// <summary>
-            /// Converts a tag to an equivalent <see cref="SubscriptionTier"/> value.
-            /// </summary>
-            /// <param name="tags">The IRC message tags.</param>
-            /// <param name="key">The tag to convert.</param>
-            /// <returns>
-            /// Returns the equivalent <see cref="SubscriptionTier"/> value if the tag was able to be converted.
-            /// Returns <see cref="SubscriptionTier.Other"/> otherwise.
-            /// </returns>
-            public static SubscriptionTier
-            ToSubscriptionPlan(in IrcMessage message, string key)
-            {
-                if (!IsTagValid(message, key))
-                {
-                    return SubscriptionTier.Other;
-                }
-
-                EnumUtil.TryParse(message.tags[key], out SubscriptionTier plan);
-
-                return plan;
-            }
-
-            /// <summary>
-            /// Converts a tag to an equivalent <see cref="RitualType"/> value.
-            /// </summary>
-            /// <param name="tags">The IRC message tags.</param>
-            /// <param name="key">The tag to convert.</param>
-            /// <returns>
-            /// Returns the equivalent <see cref="RitualType"/> value if the tag was able to be converted.
-            /// Returns <see cref="RitualType.Other"/> otherwise.
-            /// </returns>
-            public static RitualType
-            ToRitualType(in IrcMessage message, string key)
-            {
-                if (!IsTagValid(message, key))
-                {
-                    return RitualType.Other;
-                }
-
-                EnumUtil.TryParse(message.tags[key], out RitualType type);
-
-                return type;
-            }
-
-            /// <summary>
-            /// Converts a tag to an equivalent <see cref="BroadcasterLanguage"/> value.
-            /// </summary>
-            /// <param name="tags">The IRC message tags.</param>
-            /// <param name="key">The tag to convert.</param>
-            /// <returns>
-            /// Returns the equivalent <see cref="BroadcasterLanguage"/> value if the tag was able to be converted.
-            /// Returns <see cref="BroadcasterLanguage.None"/> otherwise.
-            /// </returns>
-            public static BroadcasterLanguage
-            ToBroadcasterLanguage(in IrcMessage message, string key)
-            {
-                if (!IsTagValid(message, key))
-                {
-                    return BroadcasterLanguage.None;
-                }
-
-                EnumUtil.TryParse(message.tags[key], out BroadcasterLanguage language);
-
-                return language;
+                return _value;
             }
 
             /// <summary>
@@ -666,19 +562,19 @@ TwitchNet.Clients.Irc
             /// Returns <see cref="Color.Empty"/> otherwise.
             /// </returns>
             public static Color
-            FromtHtml(in IrcMessage message, string key)
+            FromtHtml(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return Color.Empty;
                 }
 
-                if (!message.tags[key].IsValidHtmlColor())
+                if (!value.IsValidHtmlColor())
                 {
                     return Color.Empty;
                 }
 
-                return ColorTranslator.FromHtml(message.tags[key]);
+                return ColorTranslator.FromHtml(value);
             }
 
             /// <summary>
@@ -691,19 +587,19 @@ TwitchNet.Clients.Irc
             /// Returns <see cref="Color.Empty"/> otherwise.
             /// </returns>
             public static DateTime
-            FromUnixEpochMilliseconds(in IrcMessage message, string key)
+            FromUnixEpochMilliseconds(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return DateTime.MinValue;
                 }
 
-                if (!Int64.TryParse(message.tags[key], out long time_epoch))
+                if (!Int64.TryParse(value, out long _value))
                 {
                     return DateTime.MinValue;
                 }
 
-                return time_epoch.FromUnixEpochMilliseconds();
+                return _value.FromUnixEpochMilliseconds();
             }
 
             /// <summary>
@@ -716,21 +612,21 @@ TwitchNet.Clients.Irc
             /// Returns an empty <see cref="Badge"/> array otherwise.
             /// </returns>
             public static Badge[]
-            ToBadges(in IrcMessage message, string key)
+            ToBadges(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return new Badge[0];
                 }
 
-                string[] badge_pairs = message.tags[key].Split(',');
-                if (badge_pairs.Length == 0)
+                string[] pairs = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                if (pairs.Length == 0)
                 {
                     return new Badge[0];
                 }
 
                 List<Badge> badges = new List<Badge>();
-                foreach (string pair in badge_pairs)
+                foreach (string pair in pairs)
                 {
                     Badge badge = new Badge(pair);
                     badges.Add(badge);
@@ -739,22 +635,31 @@ TwitchNet.Clients.Irc
                 return badges.ToArray();
             }
 
+            /// <summary>
+            /// Converts a tag to an equivalent array of <see cref="BadgeInfo"/> values.
+            /// </summary>
+            /// <param name="tags">The IRC message tags.</param>
+            /// <param name="key">The tag to convert.</param>
+            /// <returns>
+            /// Returns the equivalent array of <see cref="BadgeInfo"/> values if the tag was able to be converted.
+            /// Returns an empty <see cref="BadgeInfo"/> array otherwise.
+            /// </returns>
             public static BadgeInfo[]
-            ToBadgeInfo(in IrcMessage message, string key)
+            ToBadgeInfo(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return new BadgeInfo[0];
                 }
 
-                string[] badge_pairs = message.tags[key].Split(',');
-                if (!badge_pairs.IsValid())
+                string[] pairs = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                if (!pairs.IsValid())
                 {
                     return new BadgeInfo[0];
                 }
 
                 List<BadgeInfo> badge_info = new List<BadgeInfo>();
-                foreach (string pair in badge_pairs)
+                foreach (string pair in pairs)
                 {
                     BadgeInfo badge = new BadgeInfo(pair);
                     badge_info.Add(badge);
@@ -773,14 +678,14 @@ TwitchNet.Clients.Irc
             /// Returns an empty <see cref="Emote"/> array otherwise.
             /// </returns>
             public static Emote[]
-            ToEmotes(in IrcMessage message, string key)
+            ToEmotes(in IrcTags tags, string key)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return new Emote[0];
                 }
 
-                string[] pairs = message.tags[key].Split('/');
+                string[] pairs = value.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
                 if (pairs.Length == 0)
                 {
                     return new Emote[0];
@@ -806,47 +711,14 @@ TwitchNet.Clients.Irc
             /// Returns an empty <see cref="String"/> array otherwise.
             /// </returns>
             public static string[]
-            ToStringArray(in IrcMessage message, string key, char separator)
+            ToStringArray(in IrcTags tags, string key, char separator)
             {
-                if (!IsTagValid(message, key))
+                if (!tags.TryGetValue(key, out string value))
                 {
                     return new string[0];
                 }
 
-                return message.tags[key].Split(separator);
-            }
-
-            /// <summary>
-            /// Checks to see if the specified tag was included in the attached tags.
-            /// </summary>
-            /// <param name="tags">The IRC message tags.</param>
-            /// <param name="key">The tag to check.</param>
-            /// <returns>
-            /// Returns true if tags were attached in the IRC message and if the specified tag was included in the attached tags.
-            /// Returns false otherwise.
-            /// </returns>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool
-            IsTagValid(in IrcMessage message, string key)
-            {
-                bool valid = true;
-
-                if (message.IsNullOrDefault())
-                {
-                    return false;
-                }
-
-                if (!key.IsValid() || !message.tags.IsValid())
-                {
-                    return false;
-                }
-
-                if (!message.tags.ContainsKey(key) || !message.tags[key].IsValid())
-                {
-                    return false;
-                }
-
-                return valid;
+                return value.Split(separator);
             }
         }
     }

--- a/Debugger/Debug.Validation.cs
+++ b/Debugger/Debug.Validation.cs
@@ -401,7 +401,7 @@ TwitchNet.Debugger
             }
 
             IrcMessage message = GetIrcMessage(obj);
-            if (message.IsNull() || !message.tags.IsValid())
+            if (message.IsNull() || !message.tags_exist)
             {
                 return;
             }
@@ -457,7 +457,7 @@ TwitchNet.Debugger
         private static bool
         TryGetMissingTags(IrcMessage message, List<string> processed_tags_names, out string[] missing_tag_names)
         {
-            if (!message.tags.IsValid())
+            if (!message.tags_exist)
             {
                 missing_tag_names = new string[0];
 
@@ -466,20 +466,20 @@ TwitchNet.Debugger
 
             if (!processed_tags_names.IsValid())
             {
-                missing_tag_names = message.tags.Keys.ToArray();
+                missing_tag_names = message.tags.keys;
 
                 return false;
             }
 
             List<string> missing = new List<string>();
-            foreach (string key in message.tags.Keys)
+            foreach (IrcTag tag in message.tags)
             {
-                if (processed_tags_names.Contains(key))
+                if (processed_tags_names.Contains(tag.key))
                 {
                     continue;
                 }
 
-                missing.Add(key);
+                missing.Add(tag.key);
             }
 
             missing_tag_names = missing.ToArray();
@@ -490,9 +490,9 @@ TwitchNet.Debugger
         private static bool
         TryGetExtraTags(IrcMessage message, List<string> processed_tags_names, out string[] extra_tag_names)
         {
-            if (!message.tags.IsValid())
+            if (!message.tags_exist)
             {
-                extra_tag_names = message.tags.Keys.ToArray();
+                extra_tag_names = message.tags.keys;
 
                 return false;
             }
@@ -507,7 +507,7 @@ TwitchNet.Debugger
             List<string> extra = new List<string>();
             foreach (string tag in processed_tags_names)
             {
-                if (message.tags.Keys.Contains(tag))
+                if (message.tags.ContainsKey(tag))
                 {
                     continue;
                 }


### PR DESCRIPTION
The IRC tags dictionary has been replaces with a custom struct that behaves the same as a read-only dictionary. This should make it so that IRC messages are now laid out in continuous memory.

Fixed a couple bugs with converting tags to arrays that would return an array with a single default element instead of an empty array.